### PR TITLE
New make target bundle-for-test

### DIFF
--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -46,6 +46,8 @@ jobs:
           registry: ${{ env.REGISTRY }}
       - name: print image url
         run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+      - name: generate test bundle
+        run: VERSION=${{ env.TAGS }} PLG_VERSION=${{ env.TAGS }} FLP_VERSION=${{ env.TAGS }} BPF_VERSION=${{ env.TAGS }} make bundle-for-test
       - name: build bundle
         run: VERSION=${{ env.TAGS }} IMAGE_TAG_BASE=${{ env.REGISTRY }}/${{ env.IMAGE }} make bundle-build
       - name: push bundle to quay.io


### PR DESCRIPTION
@memodi I think it should fix the issue you have.
I tested this bundle-for-test generation, but not the whole integration with OLM.
It will generate a bundle versioned "0.0.0-main" (operator-sdk requires to have a semver-like version, we can't just use "main")